### PR TITLE
Pj/feat/cafe controller with location

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,58 @@ This app was a prize winner at the Athena Hackathon 2023 for the team comprising
 [React Native Docs - Navigating between screens](https://reactnative.dev/docs/navigation) - This is what I (Pablo) used as reference when setting up the screens stack in App.js.
 
 [React Nagigation - Getting Started](https://reactnavigation.org/docs/getting-started/) - This is what I didn't but probably should have used as reference when setting up the screens stack in App.js.
+
+## Developer Notes (Information and Learning Sharing)
+
+### Using Location
+
+#### Location in the CafeModel (backend > models > CafeModel.js)
+
+The `location` property in the `CafeModel` is an object with the following properties:
+
+* `type` - The type of the location. This is a string and can be either `Point` or `Polygon`. We are using `Point` for the location of the cafes.
+* `coordinates` - An array of two numbers representing latitude and longitude, that MongoDB uses for geospatial data.
+
+An index has been set up on the `location` property in the `CafeModel` to allow for efficient geospatial queries. Indexing allows for improved query performance, especially when working with large datasets, joins and aggregations, but at the cost of additional storage and decreased write performance. It is essential for efficient geospatial queries.
+
+#### Using the location in the cafeController (backend > controllers > cafeController.js)
+
+The `getCafesByFacilitiesAndLocation` (current name and liable to change) function in the `cafeController` uses an aggregation pipeline to query the cafes by location and facilities, including an aggregated location query.
+
+```javascript
+$geoNear: {
+  near: {
+    type: 'Point',
+    coordinates: [latitude, longitude],
+  },
+  distanceField: 'distance',
+  maxDistance: maxDistance, // in meters, i.e., 5000 = 5km
+  spherical: true,
+}
+```
+
+The `$geoNear` stage is a geospatial query that returns documents based on their proximity to a given point. It requires a geospatial index to be set up on the location field, which we have done in the `CafeModel`. The `coordinates` property in the `near` object is an array of two numbers representing latitude and longitude provided as params in the request. 
+
+The `distanceField` property is the name of the field that will be added to the output documents. This field contains the calculated distance between the input coordinates and the location of the document. 
+
+The `maxDistance` property is the maximum distance from the center point that the documents can be returned. This value has a default but may also be passed as a param in the request.
+
+The `spherical` property is a boolean that specifies the type of calculation to perform. When `true`, MongoDB uses spherical geometry to calculate distances in 2dsphere index. When `false`, MongoDB uses planar geometry to calculate distances on a flat surface. 
+
+### getCafesByFacilitiesAndLocation controller function query (backend > controllers > cafeController.js)
+
+Please update this section as the controller function is developed, including any name changes reflecting the function's purpose.
+
+The query has two main parts: the loaction query and the facilities query:
+* The location query is an aggregation pipeline with a `$geoNear` stage that returns documents based on their proximity to a given point. It is described in more detail [here](#using-location-in-the-cafemodel-backend--models--cafemodeljs).
+* The facilities query is a standard MongoDB query that returns documents based on the facilities provided in the request. The query object is constructed prior to the query for readability as it is based on a ternary depending on the params passed in the request.
+```javascript
+const facilitiesQuery = requiredFacilities
+    ? { $all: requiredFacilities.split(',') }
+    : { $in: facilities.split(',') };
+```
+If any `requiredFacilities` are passed in the request, the query will return documents that contain ALL of those facilities. If no `requiredFacilities` are passed, the query will return documents that contain ANY of the facilities passed in the `facilities` param.
+
+Overall, the query returns documents that are within the specified distance of the input coordinates AND contain the specified facilities to a limit of 20 objects.
+
+

--- a/backend/controllers/cafeController.js
+++ b/backend/controllers/cafeController.js
@@ -3,6 +3,7 @@ const defaultDistance = 5000; // in meters, i.e., 5000 = 5km
 
 exports.getCafesByFacilitiesAndLocation = async (req, res, next) => {
   const { facilities, requiredFacilities, userLocation } = req.query;
+  const maxDistance = Number(req.query.distance) || defaultDistance;
 
   if ((!requiredFacilities && !facilities) || !userLocation) {
     throw new Error('Both facilities and location are required.');
@@ -14,6 +15,7 @@ exports.getCafesByFacilitiesAndLocation = async (req, res, next) => {
 
   try {
     const [latitude, longitude] = userLocation.split(',').map(Number);
+    console.log('latitude:', latitude, 'longitude:', longitude, 'distance:', maxDistance);
 
     const matchingCafes = await Cafe.aggregate([
       {
@@ -23,7 +25,7 @@ exports.getCafesByFacilitiesAndLocation = async (req, res, next) => {
             coordinates: [latitude, longitude],
           },
           distanceField: 'distance',
-          maxDistance: 5000, // in meters, i.e., 5000 = 5km
+          maxDistance: maxDistance, // in meters, i.e., 5000 = 5km
           spherical: true,
         },
       },

--- a/backend/controllers/cafeController.js
+++ b/backend/controllers/cafeController.js
@@ -14,8 +14,9 @@ exports.getCafesByFacilitiesAndLocation = async (req, res, next) => {
     ? { $all: requiredFacilities.split(',') }
     : { $in: facilities.split(',') };
 
+  const [latitude, longitude] = userLocation.split(',').map(Number);
+
   try {
-    const [latitude, longitude] = userLocation.split(',').map(Number);
 
     const matchingCafes = await Cafe.aggregate([
       {
@@ -45,4 +46,6 @@ exports.getCafesByFacilitiesAndLocation = async (req, res, next) => {
     next(error);
   }
 };
+
+// NOTE: Information regarding the query in this controller and about the use of location may be found in the README.md file in the root of the project.
 

--- a/backend/controllers/cafeController.js
+++ b/backend/controllers/cafeController.js
@@ -1,14 +1,45 @@
-const Cafe = require('../models/cafeModel')
+const Cafe = require('../models/cafeModel');
+const defaultDistance = 5000; // in meters, i.e., 5000 = 5km
 
 exports.getCafesByFacilitiesAndLocation = async (req, res, next) => {
-  const { facilities, requiredFacilities } = req.query;
-  const requestedFacilities = requiredFacilities ? requiredFacilities : facilities;
-  const requestedFacilitiesArray = requestedFacilities.split(',');
+  const { facilities, requiredFacilities, userLocation } = req.query;
+
+  if ((!requiredFacilities && !facilities) || !userLocation) {
+    throw new Error('Both facilities and location are required.');
+  }
+
+  const facilitiesQuery = requiredFacilities
+    ? { $all: requiredFacilities.split(',') }
+    : { $in: facilities.split(',') };
 
   try {
-    const matchingCafes = await Cafe.find({ facilities: { $in: requestedFacilitiesArray } });
+    const [latitude, longitude] = userLocation.split(',').map(Number);
+
+    const matchingCafes = await Cafe.aggregate([
+      {
+        $geoNear: {
+          near: {
+            type: 'Point',
+            coordinates: [latitude, longitude],
+          },
+          distanceField: 'distance',
+          maxDistance: 5000, // in meters, i.e., 5000 = 5km
+          spherical: true,
+        },
+      },
+      {
+        $match: {
+          facilities: facilitiesQuery,
+        },
+      },
+      {
+        $limit: 20,
+      },
+    ]);
+
     res.status(200).json(matchingCafes);
   } catch (error) {
+    console.error('Error:', error.message);
     next(error);
   }
 };

--- a/backend/controllers/cafeController.js
+++ b/backend/controllers/cafeController.js
@@ -1,12 +1,13 @@
 const Cafe = require('../models/cafeModel');
-const defaultDistance = 5000; // in meters, i.e., 5000 = 5km
+// NOTE: The 5km below is an arbitary decision until we decide as a group what we think is a reasonable default distance
+const defaultDistance = 5000; // in meters, i.e., 5000 = 5km 
 
 exports.getCafesByFacilitiesAndLocation = async (req, res, next) => {
   const { facilities, requiredFacilities, userLocation } = req.query;
   const maxDistance = Number(req.query.distance) || defaultDistance;
 
   if ((!requiredFacilities && !facilities) || !userLocation) {
-    throw new Error('Both facilities and location are required.');
+    return next({status: 400, message: 'Both facilities and location are required.'});
   }
 
   const facilitiesQuery = requiredFacilities
@@ -15,7 +16,6 @@ exports.getCafesByFacilitiesAndLocation = async (req, res, next) => {
 
   try {
     const [latitude, longitude] = userLocation.split(',').map(Number);
-    console.log('latitude:', latitude, 'longitude:', longitude, 'distance:', maxDistance);
 
     const matchingCafes = await Cafe.aggregate([
       {
@@ -45,3 +45,4 @@ exports.getCafesByFacilitiesAndLocation = async (req, res, next) => {
     next(error);
   }
 };
+

--- a/backend/models/cafeModel.js
+++ b/backend/models/cafeModel.js
@@ -6,6 +6,7 @@ const cafeSchema = new mongoose.Schema({
     location: { type: String, required: true },
     phone: { type: String },
     website: { type: String },
+    // Opening hours required and here as a suggestion placeholder. The exact format to be decided by whoever implements the use of this data in querying only open cafes. Feel free to ammend as needed.
     openingHours: [
       { open: { type: String }, close: { type: String } },
       { open: { type: String }, close: { type: String } },
@@ -39,3 +40,5 @@ const cafeSchema = new mongoose.Schema({
 cafeSchema.index({ location: '2dsphere' });
 
 module.exports = mongoose.model('Cafe', cafeSchema, 'cafes');
+
+// NOTE: Information about the use of the location field and the location index may be found in the README.md file in the root of the project.

--- a/backend/models/cafeModel.js
+++ b/backend/models/cafeModel.js
@@ -6,13 +6,36 @@ const cafeSchema = new mongoose.Schema({
     location: { type: String, required: true },
     phone: { type: String },
     website: { type: String },
+    openingHours: [
+      { open: { type: String }, close: { type: String } },
+      { open: { type: String }, close: { type: String } },
+      { open: { type: String }, close: { type: String } },
+      { open: { type: String }, close: { type: String } },
+      { open: { type: String }, close: { type: String } },
+      { open: { type: String }, close: { type: String } },
+      { open: { type: String }, close: { type: String } },
+    ],
   },
   images: [{
     url: { type: String, required: true },
     title: { type: String, required: true },
     altText: { type: String, required: true }
   }],
-  facilities: [],
+  facilities: [String],
+
+  location: {
+    type: {
+      type: String,
+      enum: ['Point'],
+      default: 'Point',
+    },
+    coordinates: {
+      type: [Number],
+      required: true,
+    },
+  },
 });
+
+cafeSchema.index({ location: '2dsphere' });
 
 module.exports = mongoose.model('Cafe', cafeSchema, 'cafes');

--- a/backend/seed-data/cafeSeedData.js
+++ b/backend/seed-data/cafeSeedData.js
@@ -15,6 +15,10 @@ const cafeSeedData = [
       },
     ],
     facilities: ['wheelchair accessibility', 'wi-fi', 'toilets'],
+    location: {
+      type: "Point",
+      coordinates: [51.5089, -0.1264],
+    },
   },
 
   {
@@ -41,6 +45,10 @@ const cafeSeedData = [
       'visual impaired',
       'outdoor area',
     ],
+    location: {
+      type: "Point",
+      coordinates: [51.5297, -0.1270],
+    },
   },
 
   {
@@ -61,12 +69,17 @@ const cafeSeedData = [
     ],
     facilities: [
       'wheelchair accessibility',
-      'wi-fi',
+      'autism friendly',
       'toilets',
-      'baby changing',
       'visual impaired',
     ],
+    location: {
+      type: "Point",
+      coordinates: [51.5076, -0.0994],
+    },
   },
 ];
 
 module.exports = cafeSeedData;
+
+// In original data, Tate Modern Corner DOES HAVE wifi & baby changing but DOES NOT HAVE autism friendly facilities. I changed this for testing purposes. 


### PR DESCRIPTION
Provisional controller function to use userLocation to identify suitable cafes.

- [x] function requires either facilities array and/or requiredFacilites array. If both are provided, the facilities array will be ignored.
- [x] function requires a location in the form of latitude,longitude in params, e.g. ?userLocation=51.5076,-0.0994
- [x] function takes an optional distance param as the max distance but will otherwise default, currently set to 5km.
- [x] function matches ALL requiredFacilities if provided.
- [x] function matches ANY facilities if no requiredFacilities provided.
- [x] function matches the above and cafes within given range.
- [x] distance from userLocation added to returned cafes.
- [x] Currently, cafes are ordered by distance only.

Additionally, 

- [x] the cafe Model has been changed to include location data.
- [x] seed data has had location data added and the test db has been updated.
- [x] the cafe model has a provisional addition of openingHours which is nothing to do with this feature but I noticed it was missing.

To be done later, in another ticket...
NO opening hours data has been added to seeds.
Cafes should be selected ONLY when they are open.
NOTE: This should really happen in the query and not by filtering the returned data.