### PR TITLE
Pj/fix/tidy up

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -52,7 +52,8 @@ export default function App() {
         <Stack.Screen
           name="Facilities"
           component={FacilitySelectorScreen}
-          options={{ title: "Aura" }}
+          // options={{ title: "Aura" }}
+          options={{ headerShown: false }}
         />
       </Stack.Navigator>
       <MenuBar location={location}></MenuBar>

--- a/frontend/src/components/Button/ButtonStyles.js
+++ b/frontend/src/components/Button/ButtonStyles.js
@@ -1,16 +1,17 @@
 import { StyleSheet } from "react-native";
+import { globalColours } from "../../styles/globalColourVariables";
 
 export const styles = StyleSheet.create({
   container: {
     elevation: 8,
-    backgroundColor: "#2E8B57",
+    backgroundColor: globalColours.primaryButtonBackground,
     borderRadius: 10,
     paddingVertical: 15,
     paddingHorizontal: 20
   },
   text: {
     fontSize: 18,
-    color: "#fff",
+    color: globalColours.lightText,
     fontWeight: "bold",
     alignSelf: "center",
     textTransform: "uppercase"

--- a/frontend/src/components/Facility/Facility.js
+++ b/frontend/src/components/Facility/Facility.js
@@ -2,7 +2,8 @@ import React from "react";
 import { View, Text, Pressable } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { styles } from "./FacilityStyles";
-import { styleVariables } from "../../styles/globalStyleVariables";
+import { globalColours } from "../../styles/globalColourVariables";
+
 const Facility = ({
   icon,
   name,
@@ -20,10 +21,10 @@ const Facility = ({
           styles.iconContainer,
           {
             backgroundColor: isDoubleSelected
-              ? styleVariables.doubleSelectedIcon
+              ? globalColours.doubleSelectedIcon
               : pressed || isSelected
-                ? styleVariables.singleSelectedIcon
-                : styleVariables.unselectedIcon
+                ? globalColours.singleSelectedIcon
+                : globalColours.unselectedIcon
           }
         ]}
       >

--- a/frontend/src/components/Facility/Facility.js
+++ b/frontend/src/components/Facility/Facility.js
@@ -3,8 +3,14 @@ import { View, Text, Pressable } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { styles } from "./FacilityStyles";
 import { styleVariables } from "../../styles/globalStyleVariables";
-const Facility = ({ icon, name, onPress, onLongPress, isSelected, isDoubleSelected }) => {
-
+const Facility = ({
+  icon,
+  name,
+  onPress,
+  onLongPress,
+  isSelected,
+  isDoubleSelected
+}) => {
   return (
     <View style={styles.container}>
       <Pressable
@@ -14,10 +20,10 @@ const Facility = ({ icon, name, onPress, onLongPress, isSelected, isDoubleSelect
           styles.iconContainer,
           {
             backgroundColor: isDoubleSelected
-              ? styleVariables.doubleSelected
+              ? styleVariables.doubleSelectedIcon
               : pressed || isSelected
-                ? styleVariables.singleSelected
-                : styleVariables.unselected
+                ? styleVariables.singleSelectedIcon
+                : styleVariables.unselectedIcon
           }
         ]}
       >

--- a/frontend/src/components/FacilityForm/FacilityFormStyles.js
+++ b/frontend/src/components/FacilityForm/FacilityFormStyles.js
@@ -1,5 +1,5 @@
 import { StyleSheet, Dimensions } from "react-native";
-import { styleVariables } from "../../styles/globalStyleVariables";
+import { globalColours } from "../../styles/globalColourVariables";
 
 const screenWidth = Dimensions.get("window").width;
 const facilityWidth = (screenWidth - 48) / 2;
@@ -37,12 +37,12 @@ export const styles = StyleSheet.create({
     marginBottom: 15
   },
   refreshIcon: {
-    backgroundColor: styleVariables.backgroundColour
+    backgroundColor: globalColours.backgroundColour
   },
   buttonContainer: {
-    flexDirection: 'row',
-    justifyContent: 'space-evenly',
-    marginTop: 20, 
-    paddingVertical: 10,
-  },
+    flexDirection: "row",
+    justifyContent: "space-evenly",
+    marginTop: 20,
+    paddingVertical: 10
+  }
 });

--- a/frontend/src/components/MenuBar/MenuBar.js
+++ b/frontend/src/components/MenuBar/MenuBar.js
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { StyleSheet } from "react-native";
 import { View } from "react-native";
-import { styleVariables } from "../../styles/globalStyleVariables";
+import { globalColours } from "../../styles/globalColourVariables";
 import Button from "../Button/Button";
 
 export default function MenuBar({ location }) {
@@ -25,6 +25,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     padding: 20,
-    backgroundColor: styleVariables.lightGreyBackground
+    backgroundColor: globalColours.lightGreyBackground
   }
 });

--- a/frontend/src/components/MenuBar/MenuBar.js
+++ b/frontend/src/components/MenuBar/MenuBar.js
@@ -25,6 +25,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     padding: 20,
-    backgroundColor: styleVariables.menuBarBackground
+    backgroundColor: styleVariables.lightGreyBackground
   }
 });

--- a/frontend/src/screens/FacilitySelectorScreen/FacilitySelectorScreen.js
+++ b/frontend/src/screens/FacilitySelectorScreen/FacilitySelectorScreen.js
@@ -1,7 +1,7 @@
 import React from "react";
 import FacilityForm from "../../components/FacilityForm/FacilityForm";
 import { View, Text, StyleSheet } from "react-native";
-import { styleVariables } from "../../styles/globalStyleVariables";
+import { globalColours } from "../../styles/globalColourVariables";
 
 const FacilitySelectorScreen = () => {
   return (
@@ -28,6 +28,6 @@ const styles = StyleSheet.create({
     height: "100%",
     paddingHorizontal: 13,
     paddingVertical: 13,
-    backgroundColor: styleVariables.lightGreenBackground
+    backgroundColor: globalColours.lightGreenBackground
   }
 });

--- a/frontend/src/screens/FacilitySelectorScreen/FacilitySelectorScreen.js
+++ b/frontend/src/screens/FacilitySelectorScreen/FacilitySelectorScreen.js
@@ -28,6 +28,6 @@ const styles = StyleSheet.create({
     height: "100%",
     paddingHorizontal: 13,
     paddingVertical: 13,
-    backgroundColor: styleVariables.greenBackground
+    backgroundColor: styleVariables.lightGreenBackground
   }
 });

--- a/frontend/src/styles/globalColourVariables.js
+++ b/frontend/src/styles/globalColourVariables.js
@@ -1,7 +1,12 @@
-export const styleVariables = {
+export const globalColours = {
   unselectedIcon: "lightgrey",
   singleSelectedIcon: "lightblue",
   doubleSelectedIcon: "#365AB7",
+
   lightGreenBackground: "#94d876",
-  lightGreyBackground: "lightgrey"
+  lightGreyBackground: "lightgrey",
+
+  primaryButtonBackground: "#2E8B57",
+
+  lightText: "#fff"
 };

--- a/frontend/src/styles/globalStyleVariables.js
+++ b/frontend/src/styles/globalStyleVariables.js
@@ -1,8 +1,7 @@
 export const styleVariables = {
-  backgroundColour: "#f5f5f5",
-  unselected: "lightgrey",
-  singleSelected: "lightblue",
-  doubleSelected: "#365AB7",
-  greenBackground: '#94d876',
-  menuBarBackground: "lightgrey"
+  unselectedIcon: "lightgrey",
+  singleSelectedIcon: "lightblue",
+  doubleSelectedIcon: "#365AB7",
+  lightGreenBackground: "#94d876",
+  lightGreyBackground: "lightgrey"
 };


### PR DESCRIPTION
Odd changes here and there to keep things in line with our declared best practices. 

- created/refactored global colour variables for readability and consistency.
- renamed global style variables to globalColours for accuracy and brevity.
- trial removal of app header to gain space (to be discussed)
- deletion of empty test files (to be created as needed)

With the exception of the header removal this is just a tidy-up of the app based on the yet unpublished best practices. Name changes are generally to be clearer about purpose and colour variables made more descriptive of the colour rather than specific use since the whole idea is to make them general use.

The header itself is a discussion point. I think in the future, we may use it for where we are currently displaying CAFES but currently just takes up a lot of needed space. The app certainly looks much better, IMHO, without it on an iOS SE iPhone. The code it is replacing has been left commented on purposes for easy reinstatement